### PR TITLE
Fix word_ladder CLI failing due to missing arg

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import unittest
 from nose.tools import raises
 from nose.tools import ok_, eq_
-from word_ladder.cli import main, parse_args
+from word_ladder.cli import main, run, parse_args
 
 
 class TestCli(unittest.TestCase):
@@ -9,6 +9,10 @@ class TestCli(unittest.TestCase):
     @raises(SystemExit)
     def test_cli_with_no_arguments_should_fail(self):
         parse_args()
+
+    @raises(SystemExit)
+    def test_main_as_seen_from_setup_tools(self):
+        main()
 
     def test_cli_with_arguments_should_parse(self):
         args = parse_args(['from', 'fear', 'to' , 'sail', 'using', 'file'])
@@ -30,7 +34,10 @@ class TestCli(unittest.TestCase):
           "using": True
         }
 
-        eq_(main(args), ['ola', 'olo'])
+        eq_(run(args), ['ola', 'olo'])
+
+
+
 
 
 

--- a/word_ladder/cli.py
+++ b/word_ladder/cli.py
@@ -26,7 +26,7 @@ import sys
 from docopt import docopt
 from word_ladder import WordLadder, __version__
 
-def main(args):
+def run(args):
     result = WordLadder(
         args['<dict_file>']).find_path(
             args['<from>'],
@@ -40,5 +40,9 @@ def main(args):
 def parse_args(args=sys.argv):
     return docopt(__doc__, args, version=__version__)
 
+def main():
+    print('path: {0}'.format(run(parse_args())))
+
 if __name__ == '__main__':
-    print('path: {0}'.format(main(parse_args())))
+    main()
+


### PR DESCRIPTION
The error
```
$ word_ladder
Traceback (most recent call last):
  File "/home/snebel29/word_ladder/bin/word_ladder", line 9, in <module>
    load_entry_point('word-ladder==0.0.1', 'console_scripts', 'word_ladder')()
TypeError: main() missing 1 required positional argument: 'args'
```